### PR TITLE
Set on_delete on foreign keys

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@
 History
 -------
 
+* Add `on_delete=models.CASCADE` on foreign keys for Django 2.0
+
 0.6.1 (2017-06-08
 +++++++++++++++++
 

--- a/donations/models.py
+++ b/donations/models.py
@@ -58,10 +58,11 @@ class Donation(models.Model):
 
     # https://github.com/django-money/django-money
     amount = MoneyField(max_digits=10, decimal_places=2, default_currency='GBP')
-    provider = models.ForeignKey(DonationProvider, related_name='donations')
-    frequency = models.ForeignKey(Frequency, related_name='donations')
+    provider = models.ForeignKey(DonationProvider, related_name='donations', on_delete=models.CASCADE)
+    frequency = models.ForeignKey(Frequency, related_name='donations', on_delete=models.CASCADE)
     datetime = models.DateTimeField(default=timezone.now)
-    donor = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, related_name='donations')
+    donor = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, related_name='donations',
+                              on_delete=models.CASCADE)
     donor_display_name = models.CharField(blank=True, null=True, max_length=255,
                                           help_text="display name returned by the provider")
     status = models.CharField(default='Unverified', choices=DONATION_STATUSES, max_length=50)


### PR DESCRIPTION
Fixes deprecation warning `RemovedInDjango20Warning: on_delete will be a required arg for ForeignKey in Django 2.0.`