### PR TITLE
Prepare for Django 2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+* Add `on_delete=models.CASCADE` on foreign keys in migrations
+* Migrate URL confs to Django 2.0 syntax
+* Use django-compat for importing `reverse`
+
 0.6.2 (2017-06-09)
 ++++++++++++++++++
 

--- a/donations/urls.py
+++ b/donations/urls.py
@@ -1,9 +1,20 @@
 # -*- coding: utf-8
 from __future__ import unicode_literals, absolute_import
 
+from django import VERSION
 from django.conf.urls import include, url
 
 from donations.views import DonateAPI, VerifyAPI
+
+
+def include_dj20(patterns, app_name, namespace):
+    if VERSION < (1, 9):
+        return include(patterns, namespace=namespace)
+    else:
+        return include((patterns, app_name), namespace=namespace)
+
+
+app_name = 'donations'
 
 api_urls = [
     url(r'^donate/$', DonateAPI.as_view(), name="donate"),
@@ -11,9 +22,9 @@ api_urls = [
 ]
 
 donations = [
-    url(r'^api/', include(api_urls, namespace="api")),
+    url(r'^api/', include_dj20(api_urls, app_name='donations', namespace="api")),
 ]
 
 urlpatterns = [
-    url(r'^', include(donations, namespace="donations"))
+    url(r'^', include_dj20(donations, app_name='donations', namespace="donations"))
 ]

--- a/donations/views.py
+++ b/donations/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8
 from __future__ import unicode_literals, absolute_import
 
-from django.core.urlresolvers import reverse
+from compat import reverse
 from django.http import HttpResponseRedirect
 from django.views.generic import CreateView
 from rest_framework import status

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_requires = [
     'requests',
     'py-moneyed',
     'six',
+    'django-compat>=1.0.11',
 ]
 
 setup(
@@ -37,11 +38,12 @@ setup(
     zip_safe=False,
     keywords='django-donations',
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
@@ -51,5 +53,6 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8
 from __future__ import unicode_literals, absolute_import
 
-from django.core.urlresolvers import reverse
+from compat import reverse
 from django.test import TestCase
 
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8
 from __future__ import unicode_literals, absolute_import
 
-from django.conf.urls import url, include
+from django.conf.urls import url
 
-from donations.urls import urlpatterns as donations_urls
+from donations.urls import urlpatterns as donations_urls, include_dj20
 from tests.views import SimpleDonateView, FixedDonateView, DonateThankYouView
 
 test_app_urls = [
@@ -13,6 +13,6 @@ test_app_urls = [
 ]
 
 urlpatterns = [
-    url(r'^', include(donations_urls, namespace='donations')),
-    url(r'^', include(test_app_urls, namespace="testapp")),
+    url(r'^', include_dj20(donations_urls, app_name='donations', namespace='donations')),
+    url(r'^', include_dj20(test_app_urls, app_name='test-app', namespace="testapp")),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8
 from __future__ import unicode_literals, absolute_import
 
-from django.core.urlresolvers import reverse
+from compat import reverse
 from django.views.generic import TemplateView
 
 from donations.forms import DonationForm


### PR DESCRIPTION
- Add `on_delete=models.CASCADE` on foreign keys in migrations
- Migrate URL confs to Django 2.0 syntax
- Use `django-compat` for importing `reverse`